### PR TITLE
Errors/custom http status based errors

### DIFF
--- a/Assets/Scripts/Model/AuthManager.cs
+++ b/Assets/Scripts/Model/AuthManager.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Network;
 using Presentation.Loading.Screen;
@@ -193,7 +195,8 @@ namespace Model
                 // unless the data server was restarted since the last time the player logged in. So let's check by sending the Get Player request:
                 // if it succeeds, we proceed as an existing player. If it fails with an http status 404, that is fine, and we will proceed as a new player
                 await GameRoot.Instance.PlayerManager.RequestPlayerData(playerID, new RequestParams()
-                    { Timeout = 10, Retries = 1, ErrorOnFail = ErrorType.CriticalError, IsNotFoundOk = true}); // any fail status other than 404 should go into critical error state
+                    { Timeout = 10, Retries = 1, DefaultErrorOnFail = ErrorType.CriticalError, 
+                        CustomHttpStatusBasedErrors = new Dictionary<HttpStatusCode, ErrorType> {[HttpStatusCode.NotFound]  = ErrorType.None}}); // any fail status other than 404 should go into critical error state
                    
                 // ^if the above request failed with a 404 (there was no data stored that can be recovered), proceed as a new player
                 if (string.IsNullOrEmpty(GameRoot.Instance.PlayerManager.PlayerData.playerID))

--- a/Assets/Scripts/Model/AuthManager.cs
+++ b/Assets/Scripts/Model/AuthManager.cs
@@ -172,7 +172,7 @@ namespace Model
         private async Task<bool> FetchConfigTask()
         {
            await GameRoot.Instance.ConfigManager.RequestConfig(new RequestParams() 
-               { Timeout = 10, Retries = 1, ErrorOnFail = ErrorType.CriticalError}); // go into critical error state if the request fails
+               { Timeout = 10, Retries = 1, DefaultErrorOnFail = ErrorType.CriticalError}); // go into critical error state if the request fails
             return GameRoot.Instance.ConfigManager.GameConfig.levels != null;
         }
         
@@ -184,7 +184,7 @@ namespace Model
             if (isNewPlayerWrtClient)
             {
                  await GameRoot.Instance.PlayerManager.RequestNewPlayerCreation(playerID, new RequestParams() 
-                     { Timeout = 10, Retries = 1, ErrorOnFail = ErrorType.CriticalError}); // go into critical error state if the request fails
+                     { Timeout = 10, Retries = 1, DefaultErrorOnFail = ErrorType.CriticalError}); // go into critical error state if the request fails
             }
             else // the client considers itself an existing user
             {
@@ -199,7 +199,7 @@ namespace Model
                 if (string.IsNullOrEmpty(GameRoot.Instance.PlayerManager.PlayerData.playerID))
                 {
                     await GameRoot.Instance.PlayerManager.RequestNewPlayerCreation(playerID, new RequestParams()
-                        { Timeout = 10, Retries = 1, ErrorOnFail = ErrorType.CriticalError}); // go into critical error state if the request fails
+                        { Timeout = 10, Retries = 1, DefaultErrorOnFail = ErrorType.CriticalError}); // go into critical error state if the request fails
                 }
             }
             

--- a/Assets/Scripts/Model/NetRequestManager.cs
+++ b/Assets/Scripts/Model/NetRequestManager.cs
@@ -135,15 +135,15 @@ namespace Model
                 }
 
                 // this will prompt the error state if the extra params have specified it
-                if (markFailure && extraParams.ErrorOnFail != ErrorType.None)
+                if (markFailure && errorOnFail != ErrorType.None)
                 {
-                    GameRoot.Instance.ErrorManager.EnterErrorState(extraParams.ErrorOnFail);
+                    GameRoot.Instance.ErrorManager.EnterErrorState(errorOnFail);
                 }
             }
             catch (Exception exception)
             {
                Debug.LogError($"net request manager exception: {exception.Message}");
-               GameRoot.Instance.ErrorManager.EnterErrorState(extraParams.ErrorOnFail);
+               GameRoot.Instance.ErrorManager.EnterErrorState(extraParams.DefaultErrorOnFail);
             }
 
 

--- a/Assets/Scripts/Model/NetRequestManager.cs
+++ b/Assets/Scripts/Model/NetRequestManager.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;

--- a/Assets/Scripts/Model/NetRequestManager.cs
+++ b/Assets/Scripts/Model/NetRequestManager.cs
@@ -107,10 +107,11 @@ namespace Model
                         
                         // 401 is an unauthorized error which tells us that the session
                         // needs to be refreshed, so we will attempt a reload
-                        if (sentRequest.responseCode == 401)
+                        if (statusCode == HttpStatusCode.Unauthorized)
                         {
+                            errorOnFail = ErrorType.Unauthorized;
                             Debug.LogError($"unauthorized failure (http 401), reason: {sentRequest.error}, reloading might fix the issue");
-                            GameRoot.Instance.ErrorManager.EnterErrorState(ErrorType.Unauthorized);
+                            markFailure = true;
                             break;
                         }
 
@@ -125,13 +126,11 @@ namespace Model
 
                         Debug.LogError($"http protocol error, response code: {sentRequest.responseCode} reason: {sentRequest.error}");
                         markFailure = true;
-                        response = default(TRes);
                         break;
 
                     default:
                         Debug.LogError($"other failure, reason: {sentRequest.error}");
                         markFailure = true;
-                        response = default(TRes);
                         break;
                 }
 

--- a/Assets/Scripts/Model/NetRequestManager.cs
+++ b/Assets/Scripts/Model/NetRequestManager.cs
@@ -142,7 +142,7 @@ namespace Model
     {
         public int Timeout;
         public int Retries;
-        public ErrorType ErrorOnFail;
-        public bool IsNotFoundOk; // some requests can consider an http 404 response as acceptable
+        public ErrorType DefaultErrorOnFail;
+        public Dictionary<HttpStatusCode, ErrorType> CustomHttpStatusBasedErrors;
     }
 }

--- a/Assets/Scripts/Model/NetRequestManager.cs
+++ b/Assets/Scripts/Model/NetRequestManager.cs
@@ -114,16 +114,7 @@ namespace Model
                             markFailure = true;
                             break;
                         }
-
-                        // 404 is the not found error, but it can be an acceptable response
-                        // *Only If* the caller specifies that in the extra params
-                        if (sentRequest.responseCode == 404 && extraParams.IsNotFoundOk)
-                        {
-                            Debug.LogWarning("request returned a not found error (http 404); the params say it is ok, so not marking as failure");
-                            response = default(TRes);
-                            break;
-                        }
-
+                        
                         Debug.LogError($"http protocol error, response code: {sentRequest.responseCode} reason: {sentRequest.error}");
                         markFailure = true;
                         break;

--- a/Assets/Scripts/Presentation/Gameplay/Screen/GameplayScreen.cs
+++ b/Assets/Scripts/Presentation/Gameplay/Screen/GameplayScreen.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Model;
 using Network;
@@ -86,9 +87,10 @@ namespace Presentation.Gameplay.Screen
 
             if (win || lose)
             {
-                Task<LevelResultResponse> levelResultTask = myGameplayManager.RequestLevelResult(rolls.ToArray(), new RequestParams() 
-                    {Timeout = 10, Retries = 2, DefaultErrorOnFail = ErrorType.CouldNotConnect}); // basic (recoverable) error if the request fails
-                
+                // create the level result task with the request containing the rolls, the helper 
+                // function will add the extra params needed as per our specific requirements
+                Task<LevelResultResponse> levelResultTask = SendLevelResultRequest(rolls.ToArray());
+
                 Task minDelayTask = Task.Delay(minimumLevelResultDelayMilliseconds);  // added to let the player view the dice result before changing game state
                 
                 await Task.WhenAll(levelResultTask, minDelayTask);
@@ -116,8 +118,9 @@ namespace Presentation.Gameplay.Screen
         private async Task ResendLevelResult()
         {
             rollButton.interactable = false;
-            LevelResultResponse levelResultResponse = await myGameplayManager.RequestLevelResult(rolls.ToArray(),  new RequestParams() 
-                {Timeout = 10, Retries = 2, DefaultErrorOnFail = ErrorType.CouldNotConnect}); // basic (recoverable) error if the request fails;
+            
+            // send another request, similar to the initial one
+            LevelResultResponse levelResultResponse = await SendLevelResultRequest(rolls.ToArray());
             
             if (!string.IsNullOrEmpty(levelResultResponse.playerData.playerID))
             {

--- a/Assets/Scripts/Presentation/Gameplay/Screen/GameplayScreen.cs
+++ b/Assets/Scripts/Presentation/Gameplay/Screen/GameplayScreen.cs
@@ -87,7 +87,7 @@ namespace Presentation.Gameplay.Screen
             if (win || lose)
             {
                 Task<LevelResultResponse> levelResultTask = myGameplayManager.RequestLevelResult(rolls.ToArray(), new RequestParams() 
-                    {Timeout = 10, Retries = 2, ErrorOnFail = ErrorType.CouldNotConnect}); // basic (recoverable) error if the request fails
+                    {Timeout = 10, Retries = 2, DefaultErrorOnFail = ErrorType.CouldNotConnect}); // basic (recoverable) error if the request fails
                 
                 Task minDelayTask = Task.Delay(minimumLevelResultDelayMilliseconds);  // added to let the player view the dice result before changing game state
                 
@@ -117,7 +117,7 @@ namespace Presentation.Gameplay.Screen
         {
             rollButton.interactable = false;
             LevelResultResponse levelResultResponse = await myGameplayManager.RequestLevelResult(rolls.ToArray(),  new RequestParams() 
-                {Timeout = 10, Retries = 2, ErrorOnFail = ErrorType.CouldNotConnect}); // basic (recoverable) error if the request fails;
+                {Timeout = 10, Retries = 2, DefaultErrorOnFail = ErrorType.CouldNotConnect}); // basic (recoverable) error if the request fails;
             
             if (!string.IsNullOrEmpty(levelResultResponse.playerData.playerID))
             {

--- a/Assets/Scripts/Presentation/Gameplay/Screen/GameplayScreen.cs
+++ b/Assets/Scripts/Presentation/Gameplay/Screen/GameplayScreen.cs
@@ -128,5 +128,24 @@ namespace Presentation.Gameplay.Screen
                 rollButton.interactable = true;
             }
         }
+
+        // create and send a level result request that, on failure, leads to a basic (recoverable) error,
+        // unless the http status codes are bad request (400) or internal server error (500),
+        // in which case, we should go into critical error state
+        private Task<LevelResultResponse> SendLevelResultRequest(int[] rollsToSend)
+        {
+            // create the level result task with the request containing the rolls, and the extra params with the errors
+            return myGameplayManager.RequestLevelResult(rollsToSend,
+                new RequestParams()
+                {
+                    Timeout = 10, Retries = 2, DefaultErrorOnFail = ErrorType.CouldNotConnect,
+                    CustomHttpStatusBasedErrors = new Dictionary<HttpStatusCode, ErrorType>()
+                    {
+                        [HttpStatusCode.BadRequest] = ErrorType.CriticalError,
+                        [HttpStatusCode.InternalServerError] = ErrorType.CriticalError,
+                    }
+                }
+            );
+        }
     }
 }

--- a/Assets/Scripts/Presentation/Main/Screen/MainScreen.cs
+++ b/Assets/Scripts/Presentation/Main/Screen/MainScreen.cs
@@ -88,7 +88,7 @@ namespace Presentation.Main.Screen
             playButton.interactable = false;
             
             bool canEnter = await myGameplayManager.RequestLevelEntry(levelToEnter, 
-                new RequestParams() { Timeout = 10, Retries = 2, ErrorOnFail = ErrorType.CouldNotConnect }); // basic (recoverable) error state if the request fails
+                new RequestParams() { Timeout = 10, Retries = 2, DefaultErrorOnFail = ErrorType.CouldNotConnect }); // basic (recoverable) error state if the request fails
             if (canEnter)
             {
                 playerEnergyEstimate = myPlayerManager.PlayerData.energy;


### PR DESCRIPTION
 - the request params struct now has a default error on fail which can be set to any error type
 - it also has a custom http status based error dictionary as a new property, where we can customize the error flow in case we hit specific http errors:
 - e.g. 1: the get player request in the post auth flow, which will usually go into critical error state will not throw an error if we get the 404 response from the data server, which is considered safe for this request
 - e.g. 2: the level result request, which usually goes into the basic (recoverable )error state flow in case we cannot communicate with the gameplay  server, will now go into the critical error state if we get an http 400 or 500 status